### PR TITLE
Add example-issuer.json

### DIFF
--- a/example-issuer.json
+++ b/example-issuer.json
@@ -1,0 +1,5 @@
+ {
+    "name": "Simple Healthcare Entity",
+    "logo_uri": "https://smarthealthit.org/wp-content/themes/SMART/images/logo.svg",
+    "iss": "https://simple.example.com/issuer"
+  }


### PR DESCRIPTION
Adds example issuer representation to make it easier for the SHC/VCI community to have a concrete example
of the nature of the data that'll be in vci-issuers.json