### PR TITLE
Introduce `software_logo_uri`

### DIFF
--- a/example-issuer.json
+++ b/example-issuer.json
@@ -1,5 +1,6 @@
  {
     "name": "Simple Healthcare Entity",
+    "iss": "https://simple.example.com/issuer",
     "logo_uri": "https://smarthealthit.org/wp-content/themes/SMART/images/logo.svg",
-    "iss": "https://simple.example.com/issuer"
+    "software_vendor_logo_uri": null
   }

--- a/example-issuer.json
+++ b/example-issuer.json
@@ -2,5 +2,5 @@
     "name": "Simple Healthcare Entity",
     "iss": "https://simple.example.com/issuer",
     "logo_uri": "https://smarthealthit.org/wp-content/themes/SMART/images/logo.svg",
-    "software_vendor_logo_uri": null
+    "software_logo_uri": null
   }


### PR DESCRIPTION
Add a `null` value for software logo URI in example issuer to reflect
that the value is optimal, but the key will always be present to maintain a
consistent data contract.