### PR TITLE
add Denver Health

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -591,6 +591,10 @@
     {
       "iss": "https://emrrp.ucdmc.ucdavis.edu/FHIR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "UC Davis Health"
+    },
+    {
+      "iss": "https://webservices.dhha.org/PRD-FHIR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
+      "name": "Denver Health"
     }
   ]
 }


### PR DESCRIPTION
1024 bit Diffie Hellman temporary key used
validate_entries succeeds on my machine current branch 

```
ivetter@EPIC91068 MINGW64 ~/OneDrive - epic.com/Documents/GitHub/vci-directory/scripts (patch-4)
$ python validate_entries.py ../vci-issuers.json               
............................................................................................
.........................................................
All entries are valid
```
