### PR TITLE
replace CMC url

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -597,7 +597,7 @@
       "name": "Denver Health"
     },
     {
-      "iss": "https://epicsoapprd.communitymedical.org/arr_OAuth/api/epic/2021/Security/Open/EcKeys/32001/SHC",
+      "iss": "https://epicsoapprd.communitymedical.org/arr_fhir/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "Community Medical Centers"
     },
     {


### PR DESCRIPTION
No credentials were issued with previous url. Replace, not addend is the correct action.