### PR TITLE
Add British Columbia, Canada

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -663,6 +663,10 @@
     {
       "iss": "https://epproxy.texashealth.org/FHIR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "Texas Health Resources"
+    },
+    {
+      "iss": "https://smarthealthcard.phsa.ca/v1/issuer",
+      "name": "Province of British Columbia"
     }
   ] 
 }


### PR DESCRIPTION
Adding the ISS retrieved from decoding the BC Vaccination Card.

https://smarthealthcard.phsa.ca/v1/issuer/.well-known/jwks.json