### PR TITLE
fix Misplaced (Idaho)

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -742,7 +742,7 @@
     },
     {
       "iss": "https://uhealthsoap.med.miami.edu/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
-      "name": "UHealth – University of Miami Health System (Idaho)"
+      "name": "UHealth – University of Miami Health System"
     },
     {
       "iss": "https://epicfhir.phs.org/FHIR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
@@ -790,7 +790,7 @@
     },
     {
       "iss": "https://epincoming.slhs.org/Interconnect-FHIR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
-      "name": "St. Luke’s Health System"
+      "name": "St. Luke’s Health System (Idaho)"
     },
     {
       "iss": "https://fhir.lakelandregional.org/fhirproxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",


### PR DESCRIPTION
There was a typo where (Idaho) was placed next to the wrong org.