### PR TITLE
Add Quebec's Key

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -1145,12 +1145,17 @@
     {
       "iss": "https://fhirdev.hfhs.org/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "Henry Ford Health System",
-	    "website": "https://www.henryford.com/"
+      "website": "https://www.henryford.com/"
     },
     {
       "iss": "https://epicsoap.readinghospital.org/FHIR-PRD/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "Tower Health",
-		  "website": "https://towerhealth.org/"
+      "website": "https://towerhealth.org/"
+    },
+    {
+      "iss": "https://covid19.quebec.ca/PreuveVaccinaleApi/issuer",
+      "name": "Gouvernement du Québec - Government of Quebec",
+      "website": "https://www.quebec.ca/vaccinationpassport"
     }
-  ] 
+  ]
 }


### PR DESCRIPTION
Adding Governemnt of Quebec's Key (Canada), following the publication of the SHC-compliant public key.
https://covid19.quebec.ca/PreuveVaccinaleApi/issuer/.well-known/jwks.json

(Issuer Request Form/Engagement was completed) 