### PR TITLE
website for UPMC, UPMC-PA, Wellspan

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -877,6 +877,7 @@
     {
       "iss": "https://interconnect.wellspan.org/interconnect-prd-fhir/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "WellSpan Health"
+      "website": "https://www.wellspan.org/"
     },
     {
       "iss": "https://scproxy.gundersenhealth.org/FHIRARR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
@@ -1166,6 +1167,7 @@
     {
       "iss": "https://epic-arr.pinnaclehealth.org/PRD-FHIR-ARR/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "UPMC Central PA"
+      "website": "https://www.upmc.com/locations/regions/south-central-pa"
     },
     {
       "iss": "https://fhir.samhealth.org/fhir-arr/api/epic/2021/Security/Open/EcKeys/32001/SHC",
@@ -1467,6 +1469,7 @@
     {
       "iss": "https://epic-fhir-prd.upmc.com/FHIR-PRD/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "University of Pittsburgh Medical Center (UPMC)"
+      "website": "https://www.upmc.com/"
     },
     {
       "iss": "https://epicsoap.nortonhealthcare.org/FHIRPRD/api/epic/2021/Security/Open/EcKeys/32001/SHC",


### PR DESCRIPTION
Grouped because they all failed the current checks. I don't believe they were failing the new tests in the CORS Headers PR.