### PR TITLE
fix UMC Southern Nevada

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -1330,7 +1330,7 @@
       "website": "https://www.houstonmethodist.org"
     },
     {
-      "iss": "https://epicproxy-np.et1023.epichosted.com/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
+      "iss": "https://epicproxy.et1023.epichosted.com/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "UMC Southern Nevada"
     },
     {


### PR DESCRIPTION
replacing UMC Southern Nevada. Not using CanonicalIss because the endpoint submitted was never valid.