### PR TITLE
VCI Issuer Metadata

### DIFF
--- a/METADATA.md
+++ b/METADATA.md
@@ -1,0 +1,10 @@
+# Issuer Metadata
+
+[`vci-issuer-metadata.json`](example-metadata.json) represents metadata about an Issuer that may be useful to applications and websites.
+
+| Attribute | Meaning |
+| `canonical_iss` | The matches the `iss` or `canonical_iss` of the issuer in `vci-issuers.json` |
+| `website` | A website where the consumer can get their SMART Health Card or learn where they can get their SMART Health Card |
+| `help_line` | A phone number a consumer can call for assistance |
+| `issuer_type` | The type of issuer |
+| `state` | Which state the issuer represents |

--- a/METADATA.md
+++ b/METADATA.md
@@ -3,8 +3,11 @@
 [`vci-issuer-metadata.json`](example-metadata.json) represents metadata about an Issuer that may be useful to applications and websites.
 
 | Attribute | Meaning |
+|-----------|---------|
 | `canonical_iss` | The matches the `iss` or `canonical_iss` of the issuer in `vci-issuers.json` |
 | `website` | A website where the consumer can get their SMART Health Card or learn where they can get their SMART Health Card |
 | `help_line` | A phone number a consumer can call for assistance |
 | `issuer_type` | The type of issuer |
 | `state` | Which state the issuer represents |
+
+[example-metadata.json](example-metadata.json) shows basic example representing what an entry in the metadata file would look like.

--- a/METADATA.md
+++ b/METADATA.md
@@ -1,6 +1,6 @@
 # Issuer Metadata
 
-[`vci-issuer-metadata.json`](example-metadata.json) represents metadata about an Issuer that may be useful to applications and websites.
+[vci-issuer-metadata.json](example-metadata.json) represents metadata about an Issuer that may be useful to applications and websites.
 
 | Attribute | Meaning |
 |-----------|---------|

--- a/METADATA.md
+++ b/METADATA.md
@@ -8,6 +8,7 @@
 | `website` | A website where the consumer can get their SMART Health Card or learn where they can get their SMART Health Card |
 | `help_line` | A phone number a consumer can call for assistance |
 | `issuer_type` | The type of issuer |
-| `state` | Which state the issuer represents |
+| `state` | Which state, province, territory, or other administrative division within a country the issuer represents |
+| `country` | The country the issuer represents as ISO 3166 2 or 3 letter code |
 
 [example-metadata.json](example-metadata.json) shows basic example representing what an entry in the metadata file would look like.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VCI Directory
 
-This repository provides a public directory of institutions issuing [SMART Health Cards](https://smarthealth.cards) for COVID-19 vaccination and laboratory diagnostic testing records. The directory, represented in the [vci-issuers.json file](https://raw.githubusercontent.com/the-commons-project/vci-directory/main/vci-issuers.json), is a simple listing of issuer name, issuer URL (`iss`), and issuer website that can be used for purposes of verification and display. Additional metadata about issuers is listed in [vci-issuers-metadata.json][vci-issuers-metadata.json]. An overview of the issuer metadata listed is described in [METADATA.md](METADATA.md).
+This repository provides a public directory of institutions issuing [SMART Health Cards](https://smarthealth.cards) for COVID-19 vaccination and laboratory diagnostic testing records. The directory, represented in the [vci-issuers.json file](vci-issuers.json), is a simple listing of issuer name, issuer URL (`iss`), and issuer website that can be used for purposes of verification and display. Additional metadata about issuers is listed in [vci-issuers-metadata.json][vci-issuers-metadata.json]. An overview of the issuer metadata listed is described in [METADATA.md](METADATA.md).
 
 [VCI™](https://vci.org) is a voluntary coalition of public and private organizations committed to empowering individuals access to a trustworthy and verifiable copy of their vaccination records in digital or paper form using open, interoperable standards. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VCI Directory
 
-This repository provides a public directory of institutions issuing [SMART Health Cards](https://smarthealth.cards) for COVID-19 vaccination and laboratory diagnostic testing records. The directory, represented in the [vci-issuers.json file](https://raw.githubusercontent.com/the-commons-project/vci-directory/main/vci-issuers.json), is a simple listing of issuer name, issuer URL (`iss`), and issuer website that can be used for purposes of verification and display.
+This repository provides a public directory of institutions issuing [SMART Health Cards](https://smarthealth.cards) for COVID-19 vaccination and laboratory diagnostic testing records. The directory, represented in the [vci-issuers.json file](https://raw.githubusercontent.com/the-commons-project/vci-directory/main/vci-issuers.json), is a simple listing of issuer name, issuer URL (`iss`), and issuer website that can be used for purposes of verification and display. Additional metadata about issuers is listed in [vci-issuers-metadata.json][vci-issuers-metadata.json]. An overview of the issuer metadata listed is described in [METADATA.md](METADATA.md).
 
 [VCI™](https://vci.org) is a voluntary coalition of public and private organizations committed to empowering individuals access to a trustworthy and verifiable copy of their vaccination records in digital or paper form using open, interoperable standards. 
 
@@ -66,4 +66,4 @@ The VCI Directory is licensed via [CC BY 4.0](https://creativecommons.org/licens
 ## Technical Features
 The VCI creates a daily snapshot of the directory, listing the issuers along with the keys retrieved from their listed `iss` endpoint. This can be used by Verifiers as an alternative mechanism to validate SMART Health Cards, without needing to connect to the directory and Issuer endpoints in real-time.
 
-The VCI runs frequent auditing scripts on the directory, to ensure ongoing availability and security compliance of the Issuer endpoints: audit validates proper endpoint TLS configuration, JWK set correctness, and detects name and key identifier collisions
+The VCI runs frequent auditing scripts on the directory, to ensure ongoing availability and security compliance of the Issuer endpoints: audit validates proper endpoint TLS configuration, JWK set correctness, and detects name and key identifier collisions.

--- a/example-metadata.json
+++ b/example-metadata.json
@@ -7,7 +7,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "CA"
+      "state": "CA",
+      "country": "US"
     }
   ]
 }

--- a/example-metadata.json
+++ b/example-metadata.json
@@ -1,0 +1,7 @@
+{
+    "canonical_iss": "https://simple.example.com",
+    "website": "https://simple.example.com/portal",
+    "help_line": "(555) 867-5309",
+    "issuer_type": ["state"],
+    "state": "CA"
+}

--- a/example-metadata.json
+++ b/example-metadata.json
@@ -1,7 +1,13 @@
 {
-    "canonical_iss": "https://simple.example.com",
-    "website": "https://simple.example.com/portal",
-    "help_line": "(555) 867-5309",
-    "issuer_type": ["state"],
-    "state": "CA"
+  "issuer_metadata": [
+    {
+      "canonical_iss": "https://simple.example.com",
+      "website": "https://simple.example.com/portal",
+      "help_line": "(555) 867-5309",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "CA"
+    }
+  ]
 }

--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -1,59 +1,77 @@
 {
-    "issuer_metadata": [
-        {
-            "canonical_iss": "https://myvaccinerecord.cdph.ca.gov/creds",
-            "website": "https://myvaccinerecord.cdph.ca.gov/",
-            "help_line": "1-555-867-5309",
-            "issuer_type": ["state"],
-            "state": "CA"
-        },
-        {
-            "canonical_iss": "https://healthcardcert.lawallet.com",
-            "website": "https://ldh.la.gov/index.cfm/faq/category/142",
-            "issuer_type": ["state"],
-            "state": "LA"
-        },
-        {
-            "canonical_iss": "https://docket.care/ut",
-            "website": "https://docket.care",
-            "issuer_type": ["state"],
-            "state": "UT"
-        },
-        {
-            "website": "https://hawaiicovid19.com/smart-health-card/",
-            "issuer_type": ["state"],
-            "state": "HI"
-        },
-        {
-            "canonical_iss": "https://docket.care/nj",
-            "website": "https://docket.care",
-            "issuer_type": ["state"],
-            "state": "NJ"
-        },
-        {
-            "canonical_iss": "https://apps.vdh.virginia.gov/credentials",
-            "website": "https://vaccinate.virginia.gov/",
-            "issuer_type": ["state"],
-            "state": "VA"
-        },
-        {
-            "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
-            "website": "https://covid19vaccine.health.ny.gov/excelsior-pass-and-excelsior-pass-plus",
-            "issuer_type": ["state"],
-            "state": "NY"
-        },
-        {
-            "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
-            "website": "https://covid19vaccine.health.ny.gov/excelsior-pass-and-excelsior-pass-plus",
-            "issuer_type": ["state"],
-            "state": "NY"
-        },
-        {
-            "canonical_iss": "https://waverify.doh.wa.gov/creds",
-            "website": "https://waverify.doh.wa.gov/",
-            "help_line": "1-800-525-0127",
-            "issuer_type": ["state"],
-            "state": "WA"
-        }
-    ]
+  "issuer_metadata": [
+    {
+      "canonical_iss": "https://myvaccinerecord.cdph.ca.gov/creds",
+      "website": "https://myvaccinerecord.cdph.ca.gov/",
+      "help_line": "1-555-867-5309",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "CA"
+    },
+    {
+      "canonical_iss": "https://healthcardcert.lawallet.com",
+      "website": "https://ldh.la.gov/index.cfm/faq/category/142",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "LA"
+    },
+    {
+      "canonical_iss": "https://docket.care/ut",
+      "website": "https://docket.care",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "UT"
+    },
+    {
+      "website": "https://hawaiicovid19.com/smart-health-card/",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "HI"
+    },
+    {
+      "canonical_iss": "https://docket.care/nj",
+      "website": "https://docket.care",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "NJ"
+    },
+    {
+      "canonical_iss": "https://apps.vdh.virginia.gov/credentials",
+      "website": "https://vaccinate.virginia.gov/",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "VA"
+    },
+    {
+      "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
+      "website": "https://covid19vaccine.health.ny.gov/excelsior-pass-and-excelsior-pass-plus",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "NY"
+    },
+    {
+      "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
+      "website": "https://covid19vaccine.health.ny.gov/excelsior-pass-and-excelsior-pass-plus",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "NY"
+    },
+    {
+      "canonical_iss": "https://waverify.doh.wa.gov/creds",
+      "website": "https://waverify.doh.wa.gov/",
+      "help_line": "1-800-525-0127",
+      "issuer_type": [
+        "state"
+      ],
+      "state": "WA"
+    }
+  ]
 }

--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -1,0 +1,59 @@
+{
+    "issuer_metadata": [
+        {
+            "canonical_iss": "https://myvaccinerecord.cdph.ca.gov/creds",
+            "website": "https://myvaccinerecord.cdph.ca.gov/",
+            "help_line": "1-555-867-5309",
+            "issuer_type": ["state"],
+            "state": "CA"
+        },
+        {
+            "canonical_iss": "https://healthcardcert.lawallet.com",
+            "website": "https://ldh.la.gov/index.cfm/faq/category/142",
+            "issuer_type": ["state"],
+            "state": "LA"
+        },
+        {
+            "canonical_iss": "https://docket.care/ut",
+            "website": "https://docket.care",
+            "issuer_type": ["state"],
+            "state": "UT"
+        },
+        {
+            "website": "https://hawaiicovid19.com/smart-health-card/",
+            "issuer_type": ["state"],
+            "state": "HI"
+        },
+        {
+            "canonical_iss": "https://docket.care/nj",
+            "website": "https://docket.care",
+            "issuer_type": ["state"],
+            "state": "NJ"
+        },
+        {
+            "canonical_iss": "https://apps.vdh.virginia.gov/credentials",
+            "website": "https://vaccinate.virginia.gov/",
+            "issuer_type": ["state"],
+            "state": "VA"
+        },
+        {
+            "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
+            "website": "https://covid19vaccine.health.ny.gov/excelsior-pass-and-excelsior-pass-plus",
+            "issuer_type": ["state"],
+            "state": "NY"
+        },
+        {
+            "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
+            "website": "https://covid19vaccine.health.ny.gov/excelsior-pass-and-excelsior-pass-plus",
+            "issuer_type": ["state"],
+            "state": "NY"
+        },
+        {
+            "canonical_iss": "https://waverify.doh.wa.gov/creds",
+            "website": "https://waverify.doh.wa.gov/",
+            "help_line": "1-800-525-0127",
+            "issuer_type": ["state"],
+            "state": "WA"
+        }
+    ]
+}

--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -7,7 +7,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "CA"
+      "state": "CA",
+      "country": "US"
     },
     {
       "canonical_iss": "https://healthcardcert.lawallet.com",
@@ -15,7 +16,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "LA"
+      "state": "LA",
+      "country": "US"
     },
     {
       "canonical_iss": "https://docket.care/ut",
@@ -23,14 +25,16 @@
       "issuer_type": [
         "state"
       ],
-      "state": "UT"
+      "state": "UT",
+      "country": "US"
     },
     {
       "website": "https://hawaiicovid19.com/smart-health-card/",
       "issuer_type": [
         "state"
       ],
-      "state": "HI"
+      "state": "HI",
+      "country": "US"
     },
     {
       "canonical_iss": "https://docket.care/nj",
@@ -38,7 +42,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "NJ"
+      "state": "NJ",
+      "country": "US"
     },
     {
       "canonical_iss": "https://apps.vdh.virginia.gov/credentials",
@@ -46,7 +51,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "VA"
+      "state": "VA",
+      "country": "US"
     },
     {
       "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
@@ -54,7 +60,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "NY"
+      "state": "NY",
+      "country": "US"
     },
     {
       "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
@@ -62,7 +69,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "NY"
+      "state": "NY",
+      "country": "US"
     },
     {
       "canonical_iss": "https://waverify.doh.wa.gov/creds",
@@ -71,7 +79,8 @@
       "issuer_type": [
         "state"
       ],
-      "state": "WA"
+      "state": "WA",
+      "country": "US"
     }
   ]
 }


### PR DESCRIPTION
Adds a `vci-issuer-metadata.json` file with metadata on the various issuers. This information is intended to provide a richer set of metadata than currently exists to assist apps and websites. This information is kept in a separate file from the primary `vci-issuers.json` file to avoid frequently changing that file which might trigger apps that depend on it to anticipate a change or addition and allow metadata to be added more liberally.

For example, we intend to use this file to help populate https://vci.org/issuers and facilitate sorting by state, pharmacy or health system issuers.

Open to any suggestions or changes!