### PR TITLE
Metadata: FHIR `Address`-like locations

### DIFF
--- a/METADATA.md
+++ b/METADATA.md
@@ -21,12 +21,12 @@ This location representation is heavily inspired by the [FHIR `Address` type][fh
 
 | Attribute | Meaning |
 |-----------|---------|
-| `state` | Which state, province, territory, or other administrative division within a country the issuer represents |
-| `country` | The country the issuer represents as ISO 3166 2 or 3 letter code |
+| `state` | The state, province, territory, or other administrative division within a country associated with the issuer |
+| `country` | The country associated with the issuer expressed as ISO 3166 2 or 3 letter code |
 
 Each location within the list of `locations` should be independently-defined. For
-example, if an issuer operations in the states of New York and New Jersey, its
-`locations` should be represented by (country should not be omitted):
+example, if an issuer has operations in the states of New York and New Jersey, each of its
+`locations` should include both state and country:
 
 
 ```json

--- a/METADATA.md
+++ b/METADATA.md
@@ -1,5 +1,7 @@
 # Issuer Metadata
 
+## Metadata Representation
+
 [vci-issuer-metadata.json](vci-issuers-metadata.json) represents metadata about an Issuer that may be useful to applications and websites.
 
 | Attribute | Meaning |
@@ -8,7 +10,32 @@
 | `website` | A website where the consumer can get their SMART Health Card or learn where they can get their SMART Health Card |
 | `help_line` | A phone number a consumer can call for assistance |
 | `issuer_type` | The type of issuer |
+| `locations` | A list of locations (see below for details) that the issuer is associated with |
+
+## Location Representation
+
+In order to best represent the reality of a SHC issuer issuing SHCs in multiple
+locations, an issuer can be associated to multiple country-state locations.
+
+This location representation is heavily inspired by the [FHIR `Address` type][fhir-address-type].
+
+| Attribute | Meaning |
+|-----------|---------|
 | `state` | Which state, province, territory, or other administrative division within a country the issuer represents |
 | `country` | The country the issuer represents as ISO 3166 2 or 3 letter code |
 
+Each location within the list of `locations` should be independently-defined. For
+example, if an issuer operations in the states of New York and New Jersey, its
+`locations` should be represented by (country should not be omitted):
+
+
+```json
+locations: [
+  { "state": "NY", "country": "US" },
+  { "state": "NJ", "country": "US" }
+]
+```
+
 [example-metadata.json](example-metadata.json) shows basic example representing what an entry in the metadata file would look like.
+
+[fhir-address-type]:https://www.hl7.org/fhir/datatypes.html#Address

--- a/example-metadata.json
+++ b/example-metadata.json
@@ -7,8 +7,9 @@
       "issuer_type": [
         "state"
       ],
-      "state": "CA",
-      "country": "US"
+      "locations": [
+        { "state": "CA", "country": "US" }
+      ]
     }
   ]
 }

--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -7,8 +7,12 @@
       "issuer_type": [
         "state"
       ],
-      "state": "CA",
-      "country": "US"
+      "locations": [
+        {
+          "state": "CA",
+          "country": "US"
+        }
+      ]
     },
     {
       "canonical_iss": "https://healthcardcert.lawallet.com",
@@ -16,8 +20,12 @@
       "issuer_type": [
         "state"
       ],
-      "state": "LA",
-      "country": "US"
+      "locations": [
+        {
+          "state": "LA",
+          "country": "US"
+        }
+      ]
     },
     {
       "canonical_iss": "https://docket.care/ut",
@@ -25,16 +33,24 @@
       "issuer_type": [
         "state"
       ],
-      "state": "UT",
-      "country": "US"
+      "locations": [
+        {
+          "state": "UT",
+          "country": "US"
+        }
+      ]
     },
     {
       "website": "https://hawaiicovid19.com/smart-health-card/",
       "issuer_type": [
         "state"
       ],
-      "state": "HI",
-      "country": "US"
+      "locations": [
+        {
+          "state": "HI",
+          "country": "US"
+        }
+      ]
     },
     {
       "canonical_iss": "https://docket.care/nj",
@@ -42,8 +58,12 @@
       "issuer_type": [
         "state"
       ],
-      "state": "NJ",
-      "country": "US"
+      "locations": [
+        {
+          "state": "NJ",
+          "country": "US"
+        }
+      ]
     },
     {
       "canonical_iss": "https://apps.vdh.virginia.gov/credentials",
@@ -51,8 +71,12 @@
       "issuer_type": [
         "state"
       ],
-      "state": "VA",
-      "country": "US"
+      "locations": [
+        {
+          "state": "VA",
+          "country": "US"
+        }
+      ]
     },
     {
       "canonical_iss": "https://ekeys.ny.gov/epass/doh/dvc/2021",
@@ -60,8 +84,12 @@
       "issuer_type": [
         "state"
       ],
-      "state": "NY",
-      "country": "US"
+      "locations": [
+        {
+          "state": "NY",
+          "country": "US"
+        }
+      ]
     },
     {
       "canonical_iss": "https://waverify.doh.wa.gov/creds",
@@ -70,8 +98,12 @@
       "issuer_type": [
         "state"
       ],
-      "state": "WA",
-      "country": "US"
+      "locations": [
+        {
+          "state": "WA",
+          "country": "US"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR migrates the representation of an issuer's location(s) to:

1. Align closer with FHIR's representation of an [`Address`](https://www.hl7.org/fhir/datatypes.html#Address).
2. Enable the desired cardinality between an issuer and its locations (1 to many).

This PR is a result of the discussion @ https://github.com/the-commons-project/vci-directory/pull/290#issuecomment-964269272 and follow up with @radamson.

cc @radamson @isaacvetter @jmandel @jpp9 (those who chimed in on that GH convo)