### PR TITLE
Additional audit capabilities 

### DIFF
--- a/scripts/vci-directory-auditor/README.md
+++ b/scripts/vci-directory-auditor/README.md
@@ -1,6 +1,6 @@
 # vci-directory-auditor
 
-Audit tool for the [VCI directory](https://github.com/the-commons-project/vci-directory/).
+Audit tool for the [VCI directory](https://github.com/the-commons-project/vci-directory/). Scripts in this project create snapshot (including issuer keys) of the VCI directory, along with an audit log.
 
 ## Setup
 
@@ -24,16 +24,66 @@ npm run build
 npm run audit -- <options>
 ```
 where `<options>` are:
-- `-d, --dirpath <dirpath>`: path of the directory to audit
-- `-o, --outpath <outpath>`: output path for the directory with keys
-- `-l, --outlogpath <outlogpath>`: 'output path for the directory log
+- `-o, --outlog <outlog>`: output directory log storing directory issuer keys, TLS details, CRLs, and errors
+- `-s, --outsnapshot <outsnapshot>`: output snapshot file storing directory issuer keys for non-erroneous issuers
+- `-p, --previous <previous>`: directory log file from a previous audit, for comparison with current one
+- `-a, --auditlog <auditlog>`: output audit file on the directory
+- `-d, --dirpath <dirpath>`: path of the directory to audit, uses "../../vci-issuers.json" by default
+- `-v, --verbose`: verbose mode
+
 
 For example, to audit the VCI directory stored in this repository, run:
 ```
 npm run audit -- -d ../../vci-issuers.json
 ```
 
+To create a directory snapshot `snapshot.json` (including issuer keys (and CRLs, if any)), a full directory log `today.json` (including issuer keys (and CRLs, if any), TLS config, and errors), and an audit log `audit.json` comparing it with a previous directory log `yesterday.json`, run:
+```
+npm run audit -- -d ../../vci-issuers.json -o today.json -s snapshot.json -p yesterday.json -a audit.json
+```
 ## Checks
 
 The tool does the following:
- - Store a copy of the directory with the issuer JWK sets
+ - Parse the specified issuer directory. For each issuer:
+   - Download and validate its JWK set
+   - Check its default TLS connection configuration (see below)
+   - If a CRL is specified in the JWK set, download and validate it
+ - Output a directory log with the issuer JWK sets (and CRLs, if any), TLS configuration, and any detected errors
+ - Output a directory snapshot with the issuer JWK sets (and CRLs, if any) for issuers without errors. This could be downloaded by SMART Health Card verifiers for offline validation
+ - Audit the directory (optionally comparing to a previous log of the directory), and report:
+   - The number of issuers
+   - The number of added and deleted issuers
+   - Issuer errors
+   - Duplicated KIDs, issuer names, iss URLs
+
+### TLS validation
+
+This tool tests conformance with [IETF BCP 195](https://www.rfc-editor.org/info/bcp195), consisting of:
+  - [RFC 7525](https://www.rfc-editor.org/info/rfc7525): Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)
+  - [RFC 8996](https://www.rfc-editor.org/info/rfc8996): Deprecating TLS 1.0 and TLS 1.1
+
+OpenSSL's `s_client` tool is used to connect to a specified server, testing the various aspects of the TLS connections. The following table summarizes the validated items.
+
+|Section         |Rule|Command|Error if|Warn if|Note|
+|----------------|--------------------|-------|--------|-------|----|
+|3.1: TLS version|MUST support TLS 1.2    |openssl s_client -connect <server>:443 -tls1_2|fails||
+|                |MUST NOT support TLS 1.0, 1.1 (and SSL)|openssl s_client -connect <server>:443 -no_tls1_2 -no_tls1_3|succeeds||From RFC 8996|
+|3.2: Strict TLS |MUST support the HTTP Strict Transport Security (HSTS) header|curl -s -D- <server> \| grep -i Strict|no match||
+|3.3: Compression|SHOULD disable TLS-level compression|openssl s_client ... \|  grep ""Compression: NONE"""||no match|
+|3.4: TLS Session Resumption|*TODO*||||
+|3.5: TLS Renegotiation|*TODO*||||
+|3.6: Server Name Indication|*TODO*||||
+|4.1: General Guideline|MUST NOT negotiate the cipher suites with NULL encryption. MUST NOT negotiate RC4 cipher suites. MUST NOT negotiate cipher suites offering less than 112 bits of security, including so-called "export-level" encryption (which provide 40 or 56 bits of security).|openssl s_client -connect \<server\>:443 -cipher NULL,EXPORT,LOW,3DES -tls1_2|succeeds||
+||SHOULD NOT negotiate cipher suites that use algorithms offering less than 128 bits of security|*TODO*|||
+||SHOULD NOT negotiate cipher suites based on RSA key transport, a.k.a. "static RSA"|*TODO*|||
+||MUST support and prefer to negotiate cipher suites offering forward secrecy, such as those in DHE and ECDHE families|*TODO*|||
+|4.2. Recommended Cipher Suites|The following cipher suites are RECOMMENDED:<br/> - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256<br/> - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256<br/> - TLS_DHE_RSA_WITH_AES_256_GCM_SHA384<br/> - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|*TODO*|||
+|4.2.1. Implementation Details|SHOULD include TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as the first proposal to any server.  Servers MUST prefer this cipher suite over weaker cipher suites whenever it is proposed, even if it is not the first proposal|*TODO*|||
+||Clients and servers SHOULD include the "Supported Elliptic Curves" extension and SHOULD support the NIST P-256 (secp256r1) curve|openssl s_client -connect \<server\>:443 -curves prime256v1 \| grep "Server Temp Key: ECDH, P-256, 256 bits"||no match|openssl doesn't have curve "secp256r1". Curve "prime256v1" uses ECDHE, curve "secp256k1" uses DHE. "|
+|4.3: Public Key Length|DH key lengths of at least 2048 bits are RECOMMENDED|openssl s_client ... \| grep "Server public key is "||if "xxxx bits" is < 2048|
+||Curves of less than 192 bits SHOULD NOT be used|*TODO*|||
+||When using RSA, servers SHOULD authenticate using certificates with at least a 2048-bit modulus for the public key|*TODO*|||
+||The use of the SHA-256 hash algorithm is RECOMMENDED|*TODO*|||
+|4.4: Modular Exponential vs. Elliptic Curve DH Cipher Suites|*TODO*||||
+|4.5: Truncated HMAC|MUST NOT use the Truncated HMAC extension||||
+|6.1: Host Name Validation|||||

--- a/scripts/vci-directory-auditor/README.md
+++ b/scripts/vci-directory-auditor/README.md
@@ -1,6 +1,6 @@
 # vci-directory-auditor
 
-Audit tool for the [VCI directory](https://github.com/the-commons-project/vci-directory/). Scripts in this project create snapshot (including issuer keys) of the VCI directory, along with an audit log.
+Audit tool for the [VCI directory](https://github.com/the-commons-project/vci-directory/). Scripts in this project create snapshot (including issuer keys and revocation information) of the VCI directory, along with an audit log.
 
 ## Setup
 
@@ -24,7 +24,7 @@ npm run build
 npm run audit -- <options>
 ```
 where `<options>` are:
-- `-o, --outlog <outlog>`: output directory log storing directory issuer keys, TLS details, CRLs, and errors
+- `-o, --outlog <outlog>`: output directory log storing directory issuer keys, TLS details, CRLs, and errors/warnings
 - `-s, --outsnapshot <outsnapshot>`: output snapshot file storing directory issuer keys for non-erroneous issuers
 - `-p, --previous <previous>`: directory log file from a previous audit, for comparison with current one
 - `-a, --auditlog <auditlog>`: output audit file on the directory

--- a/scripts/vci-directory-auditor/src/bcp195.ts
+++ b/scripts/vci-directory-auditor/src/bcp195.ts
@@ -1,0 +1,155 @@
+// Test conformance with IETF BCP 195 (https://www.rfc-editor.org/info/bcp195), consisting of:
+//  - RFC 7525: Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)
+//  - RFC 8996: Deprecating TLS 1.0 and TLS 1.1
+
+import execa from 'execa';
+import { TlsDetails } from './interfaces';
+
+// min key sizes rfc7525, section 4.3
+const MIN_EC_KEY_SIZE = 192;
+const MIN_RSA_KEY_SIZE = 2048;
+const MIN_DH_KEY_SIZE = 2048;
+
+const TLS_ERROR_PREFIX = "TLS error: ";
+
+function isOpensslAvailable(): boolean {
+    try {
+        const result = execa.commandSync("openssl version");
+        return (result.exitCode == 0);
+    } catch (err) {
+        return false;
+    }
+}
+
+const openssl = (args: string[]): execa.ExecaSyncReturnValue<string> => {
+    let result: execa.ExecaSyncReturnValue<string>;
+    try {
+        result = execa.sync('openssl', args, {timeout: 2000}); // TODO: make timeout configurable
+    }
+    catch(err) {
+        result = (err as execa.ExecaSyncReturnValue<string>);
+        if (!result) {
+            console.log(err);
+        }
+    }
+    return result;
+}
+
+// Connect to the specified server and return its default TLS connection details
+export function getDefaultTlsDetails(server: string): TlsDetails | undefined {
+    if (!isOpensslAvailable()) {
+        console.log("OpenSSL not available");
+        return undefined;
+    }
+    const result = openssl(['s_client', '-connect', `${server}:443`]);
+    if (!result || result.failed) {
+        console.log(result ? result.stderr : "openssl failed");
+        return undefined;
+    }
+
+    let version = result.stdout.match(new RegExp('^    Protocol  : (.*)$', 'm'))?.[1];
+    let cipher = result.stdout.match(new RegExp('^    Cipher    : (.*)$', 'm'))?.[1];
+    if (!version || !cipher) {
+        // with some config, the previous lines are not written; parse a different line
+        const match = result.stdout.match(new RegExp('^New, (.*), Cipher is (.*)$', 'm'));
+        version = match?.[1];
+        cipher = match?.[2];
+    }
+
+    let kexAlg = result.stdout.match(new RegExp('^Server Temp Key: (.*)$', 'm'))?.[1];
+    let authAlg = result.stdout.match(new RegExp('^Peer signature type: (.*)$', 'm'))?.[1];
+    if (!kexAlg || !authAlg) {
+        // some old ciphers don't print out the above statements, let's see if we can populate
+        // them from the OpenSSL cipher
+        if (cipher?.startsWith("AES")) {
+            // this is an OpenSSL name for static RSA kex and RSA auth
+            // see https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/openssl/tls1.h
+            kexAlg = "RSA";
+            authAlg = "RSA";
+        }
+    }
+    const pubKeySize = result.stdout.match(new RegExp('^Server public key is ([0-9]*) bit', 'm'))?.[1];
+    const compression = result.stdout.match(new RegExp('^Compression: (.*)$', 'm'))?.[1];
+    const tlsDetails = {
+        version: version,
+        cipher: cipher,
+        kexAlg: kexAlg,
+        authAlg: authAlg,
+        pubKeySize: pubKeySize,
+        compression: compression
+    }
+    return tlsDetails;
+}
+
+export function auditTlsDetails(details: TlsDetails): string[] {
+
+    if (!details.version) {
+        return [TLS_ERROR_PREFIX + "Unspecified TLS version; can't audit the TLS details"];
+    }
+
+    // any TLS 1.3 configuration is ok
+    if (details.version === "TLSv1.3") {
+        return [];
+    }
+
+    // old SSL/TLS versions are insecure
+    if (details.version !== "TLSv1.2") {
+        return [TLS_ERROR_PREFIX + `Insecure TLS version: ${details.version}`];
+    }
+
+    // audit the TLS 1.2 configuation
+    const errors:string[] = [];
+
+    // rfc7525, section 4.4: MUST support and prefer "DHE" and "ECDHE"
+    if (details.cipher?.startsWith("DHE")) {
+        // check min key length
+        if (details.kexAlg) {
+            const kexKeySize = details.kexAlg.match(new RegExp('^DH, (.*) bits$'))?.[1];
+            if (!kexKeySize || parseInt(kexKeySize) < MIN_DH_KEY_SIZE) {
+                errors.push(TLS_ERROR_PREFIX + `DHE key too small ( < ${MIN_DH_KEY_SIZE}) or can't determine size: ${kexKeySize}`);
+            }
+        }
+    } else if (details.cipher?.startsWith("ECDHE")) {
+        if (details.kexAlg) {
+            const kexKeySize = details.kexAlg.match(new RegExp('^.*, (.*) bits$'))?.[1];
+            if (!kexKeySize || parseInt(kexKeySize) < MIN_EC_KEY_SIZE) {
+                errors.push(TLS_ERROR_PREFIX + `ECDHE key too small ( < ${MIN_EC_KEY_SIZE} bits) or can't determine size: ${kexKeySize}`);
+            }
+        }
+    } else if (details.cipher?.startsWith("AES") || details.kexAlg?.startsWith("RSA")) {
+        // this is an OpenSSL name for static RSA kex and RSA auth
+        // see https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/openssl/tls1.h
+        errors.push(TLS_ERROR_PREFIX + `Static RSA SHOULD NOT be used, MUST prefer ECDHE and DHE`);
+    } else {
+        errors.push(TLS_ERROR_PREFIX + `Unrecognized cipher, MUST prefer ECDHE and DHE`);
+    }
+
+    // check signature alg
+    let authKeySize:number = -1;
+    if (details.pubKeySize) {
+        authKeySize = parseInt(details.pubKeySize);
+    }
+    if (details.authAlg == "ECDSA") {
+        if (authKeySize < 0) {
+            errors.push(TLS_ERROR_PREFIX + `Can't determine authentication public key size: ${details.pubKeySize}`);
+        } else if (authKeySize < MIN_EC_KEY_SIZE) {
+            errors.push(TLS_ERROR_PREFIX + `ECDSA key too small ( < ${MIN_EC_KEY_SIZE} bits ): ${authKeySize}`);
+        }
+    } else if (details.authAlg?.startsWith("RSA")) {
+        // could be "RSA", "RSA-PSS"
+        if (authKeySize < 0) {
+            errors.push(TLS_ERROR_PREFIX + `Can't determine authentication public key size: ${details.pubKeySize}`);
+        } else if (authKeySize < MIN_RSA_KEY_SIZE) {
+            errors.push(TLS_ERROR_PREFIX + `RSA key too small ( < ${MIN_RSA_KEY_SIZE} bits ): ${authKeySize}`);
+        }
+    } else {
+        errors.push(TLS_ERROR_PREFIX + `Unrecognized authentication algorithm: ${details.authAlg}`);
+    }
+
+    // check compression
+    if (details.compression && details.compression !== "NONE") {
+        errors.push(TLS_ERROR_PREFIX + `Uses compression: ${details.compression}`);
+    }
+
+    return errors;
+}

--- a/scripts/vci-directory-auditor/src/index.ts
+++ b/scripts/vci-directory-auditor/src/index.ts
@@ -1,172 +1,253 @@
 // Audit script for the VCI issuers directory
 
 import { Command } from 'commander';
-import { JWK } from "node-jose";
 import got from 'got';
 import fs from 'fs';
 import path from 'path';
 import date from 'date-and-time';
+import Url from 'url-parse';
+import { AuditLog, CRL, DirectoryLog, IssuerKey, IssuerKids, IssuerLogInfo, TrustedIssuers } from './interfaces';
+import { auditTlsDetails, getDefaultTlsDetails } from './bcp195';
 
 const VCI_ISSUERS_DIR_URL = "https://raw.githubusercontent.com/the-commons-project/vci-directory/main/vci-issuers.json";
-const DEFAULT_LOG_LOCATION = "logs"
-
-//
-// interfaces
-//
-
-// issuer info in the directory
-interface TrustedIssuer {
-    iss: string,
-    name: string,
-    canonical_iss?: string,
-    website?: string
-}
-
-// directory structure
-interface TrustedIssuers {
-    participating_issuers: TrustedIssuer[]
-}
-
-// issuer log info
-interface IssuerInfoWithKeys {
-    // the issuer info
-    issuer: TrustedIssuer,
-    // the issuer's JWK set
-    keys: JWK.Key[],
-}
-
-interface IssuerLogInfo extends IssuerInfoWithKeys {
-    // errors while retrieving the issuer JWK set, if any
-    errors?: string[]
-} 
-
-// Key identifiers (KID) of one issuer
-interface IssuerKids {
-    iss: string,
-    kids: string[]
-}
-
-// a snapshot of the directory, including keys
-interface DirectorySnapshot {
-    // directory URL
-    directory: string,
-    // snapshot time
-    time: string,
-    // directory issuers
-    issuerInfo: IssuerInfoWithKeys[]
-}
-
-// a snapshot of the directory, including keys
-interface DirectoryLog {
-    // directory URL
-    directory: string,
-    // snapshot time
-    time: string,
-    // directory issuers
-    issuerInfo: IssuerLogInfo[]
-}
-
 
 interface KeySet {
-    keys : JWK.Key[]
+    keys : IssuerKey[]
 }
 
 interface Options {
+    outlog: string;
+    outsnapshot: string;
+    previous: string;
+    auditlog: string;
     dirpath: string;
-    outpath: string;
-    outlogpath: string;
+    verbose: boolean;
 }
 
 //
 // program options
 //
 const program = new Command();
-program.requiredOption('-d, --dirpath <dirpath>', 'path of the directory to audit');
-program.option('-o, --outpath <outpath>', 'output path for the directory with keys');
-program.option('-l, --outlogpath <outlogpath>', 'output path for the directory log');
+program.option('-o, --outlog <outlog>', 'output directory log storing directory issuer keys, TLS details, CRLs, and errors');
+program.option('-s, --outsnapshot <outsnapshot>', 'output snapshot file storing directory issuer keys for non-erroneous issuers');
+program.option('-p, --previous <previous>', 'directory log file from a previous audit, for comparison with current one');
+program.option('-a, --auditlog <auditlog>', 'output audit file on the directory');
+program.option('-d, --dirpath <dirpath>', 'path of the directory to audit');
+program.option('-v, --verbose', 'verbose mode');
 program.parse(process.argv);
 const currentTime = new Date();
 
 // process options
 const options = program.opts() as Options;
-if (!options.outpath) {
-    options.outpath = path.join(DEFAULT_LOG_LOCATION, `directory_snapshot_${date.format(currentTime, 'YYYY-MM-DD-HHmmss')}.json`);
+if (!options.dirpath) {
+    options.dirpath = "../../vci-issuers.json";
 }
-if (!options.outlogpath) {
-    options.outlogpath = path.join(DEFAULT_LOG_LOCATION, `directory_log_${date.format(currentTime, 'YYYY-MM-DD-HHmmss')}.json`);
+if (!options.outlog) {
+    options.outlog = path.join('logs', `directory_log_${date.format(currentTime, 'YYYY-MM-DD-HHmmss')}.json`);
+}
+if (!options.outsnapshot) {
+    options.outsnapshot = path.join('logs', `directory_snapshot_${date.format(currentTime, 'YYYY-MM-DD-HHmmss')}.json`);
+}
+if (!options.auditlog) {
+    options.auditlog = path.join('logs', `audit_log_${date.format(currentTime, 'YYYY-MM-DD-HHmmss')}.json`);
 }
 
-// download the issuer keys
-async function fetchDirectoryKeys(issuers: TrustedIssuers) : Promise<DirectoryLog> {
+// download the specified directory
+async function fetchDirectory(directoryPath: string, verbose: boolean = false) : Promise<DirectoryLog> {
+    const issuers = JSON.parse(fs.readFileSync(options.dirpath).toString('utf-8')) as TrustedIssuers;
+    console.log(`Retrieving ${issuers.participating_issuers.length} issuers`);
 
-    const issuerLogInfo = issuers.participating_issuers.map(async (issuer): Promise<IssuerLogInfo> => {
+    const issuerLogInfoArray: IssuerLogInfo[] = [];
+    for (const issuer of issuers.participating_issuers) {
         const jwkURL = issuer.iss + '/.well-known/jwks.json';
         const issuerLogInfo: IssuerLogInfo = {
             issuer: issuer,
             keys: [],
+            tlsDetails: undefined,
+            crls: [],
             errors: []
         }
+        const requestedOrigin = 'https://example.org'; // request bogus origin to test CORS response
         try {
-            const response = await got(jwkURL, { timeout:10000 });
+            if (verbose) console.log("fetching jwks at " + jwkURL);
+            const response = await got(jwkURL, { headers: { Origin: requestedOrigin }, timeout:5000 });
             if (!response) {
-                throw "Can't reach JWK URL";
+                throw "Can't reach JWK set URL: " + jwkURL;
+            }
+            const acaoHeader = response.headers['access-control-allow-origin'];
+            if (!acaoHeader) {
+                issuerLogInfo.errors?.push("Issuer key endpoint does not contain a CORS 'access-control-allow-origin' header");
+            } else if (acaoHeader !== '*' && acaoHeader !== requestedOrigin) {
+                issuerLogInfo.errors?.push(`Issuer key endpoint's CORS 'access-control-allow-origin' header ${acaoHeader} does not match the requested origin`);
             }
             const keySet = JSON.parse(response.body) as KeySet;
             if (!keySet) {
-                throw "Failed to parse JSON KeySet schema";
+                issuerLogInfo.errors?.push("Failed to parse JSON KeySet schema");
             }
+            // TODO: try to import keys
             issuerLogInfo.keys = keySet.keys;
         } catch (err) {
             issuerLogInfo.errors?.push((err as Error).toString());
         }
-        return issuerLogInfo;        
-    });
-
-    const directoryLog: DirectorySnapshot = {
-        directory: VCI_ISSUERS_DIR_URL,
-        time: date.format(currentTime, 'YYYY-MM-DD HH:mm:ss'),
-        issuerInfo: []    
+        try {
+            issuerLogInfo.tlsDetails = getDefaultTlsDetails(new Url(issuer.iss).hostname);
+            if (issuerLogInfo.tlsDetails) {
+                auditTlsDetails(issuerLogInfo.tlsDetails).map(a => issuerLogInfo.errors?.push(a));
+            }
+        } catch (err) {
+            issuerLogInfo.errors?.push((err as Error).toString());
+        }
+        for (const key of issuerLogInfo.keys) {
+            if (key.crlVersion) {
+                try {
+                    const crlURL = `${issuer.iss}/.well-known/crl/${key.kid}.json`;
+                    if (verbose) console.log("fetching CRL at " + crlURL);
+                    const response = await got(crlURL, { timeout:5000 });
+                    if (!response) {
+                        throw "Can't reach CRL at " + crlURL;
+                    }
+                    const crl = JSON.parse(response.body) as CRL;
+                    if (!crl) {
+                        throw "Can't parse CRL at " + crlURL;
+                    }
+                    issuerLogInfo.crls?.push(crl);
+                } catch (err) {
+                    issuerLogInfo.errors?.push((err as Error).toString());
+                }
+            }
+        }
+        issuerLogInfoArray.push(issuerLogInfo);
+        process.stdout.write("."); // print progress marker (without newline, unlike console.log)
     }
-    try {
-        directoryLog.issuerInfo = await Promise.all(issuerLogInfo);
-    } catch(err) {
-        Promise.reject(err);
+    console.log("done"); // also puts a newline after the progress markers
+
+    const directoryLog: DirectoryLog = {
+        directory: "https://raw.githubusercontent.com/the-commons-project/vci-directory/main/vci-issuers.json", // directoryUrl, TODO
+        time: date.format(currentTime, 'YYYY-MM-DD HH:mm:ss'),
+        issuerInfo: issuerLogInfoArray
     }
 
     return directoryLog;
 }
 
-function directoryLogToSnapshot(log: DirectoryLog) : DirectorySnapshot {
-    const snapshot: DirectorySnapshot = {
+// get duplicates in a string array
+function getDuplicates(array: string[]) : string[] {
+    const set = new Set(array);
+    const duplicates = array.filter(item => {
+        if (set.has(item)) {
+            set.delete(item);
+        } else {
+            return item;
+        }
+    });
+    return Array.from(new Set(duplicates));
+}
+
+// audit the directory, optionaly comparing it to a previously obtained directory
+function audit(currentLog: DirectoryLog, previousLog: DirectoryLog | undefined) : AuditLog {
+    // get the issuers from a directory log
+    const getIssuers = (dir: DirectoryLog) => dir.issuerInfo.map(info => info.issuer.iss);
+    const currentIss = getIssuers(currentLog);
+    const auditLog: AuditLog = {
+        directory: currentLog.directory,
+        auditTime: currentLog.time,
+        issuerCount: currentLog.issuerInfo.length,
+        issuersWithErrors: currentLog.issuerInfo.filter(info => info.errors != undefined && info.errors.length > 0),
+        issuerWithCRLCount: currentLog.issuerInfo.filter(info => info.crls != undefined && info.crls.length > 0).length,
+        duplicatedKids: getDuplicates(currentLog.issuerInfo.flatMap(info => info.keys.map(key => key.kid))),
+        duplicatedIss: getDuplicates(currentIss),
+        duplicatedNames: getDuplicates(currentLog.issuerInfo.map(info => info.issuer.name))
+    }
+    if (previousLog) {
+        auditLog.previousAuditTime = previousLog?.time;
+        const initialCount = 0;
+        const previousIss = getIssuers(previousLog);
+        auditLog.newIssuerCount = currentIss.reduce((acc, current) => acc + (previousIss.includes(current) ? 0 : 1), initialCount);
+        auditLog.deletedIssuerCount = previousIss.reduce((acc, current) => acc + (currentIss.includes(current) ? 0 : 1), initialCount);
+        const getIssuerKids = (dir: DirectoryLog) => dir.issuerInfo.map(info => { return { iss: info.issuer.iss, kids: info.keys.map(key => key.kid)}});
+        const currentIssKids: IssuerKids[] = getIssuerKids(currentLog);
+        const previousIssKids: IssuerKids[] = getIssuerKids(previousLog);
+        auditLog.removedKids = [];
+        previousIssKids.forEach(pik => {
+            currentIssKids.forEach(cik => {
+                if (pik.iss === cik.iss) {
+                    const removedKids: string[] = [];
+                    pik.kids.forEach(kid => {
+                        if (!cik.kids.includes(kid)) {
+                            removedKids.push(kid);
+                        }
+                    })
+                    if (removedKids.length > 0) {
+                        auditLog.removedKids?.push({iss: pik.iss, kids: removedKids});
+                    }
+                }
+            })
+        });
+    }
+    
+    return auditLog;
+}
+
+
+function directoryLogToSnapshot(log: DirectoryLog) : DirectoryLog {
+    const snapshot: DirectoryLog = {
         directory: log.directory,
         time: log.time,
-        // don't list iss with errors, and remove errors param from IssuerLogInfo for the directory snapshot
+        // don't list issuers with errors, and remove errors param from IssuerLogInfo for the directory snapshot
         issuerInfo: log.issuerInfo.filter(ii => ii.errors ? true : false).map(ii => {
-            return {
+            const issuer: IssuerLogInfo = 
+            {
                 issuer: ii.issuer,
-                keys: ii.keys
+                keys: ii.keys,
             }
+            if (ii.crls && ii.crls.length > 0) {
+                issuer.crls = ii.crls;
+            }
+            return issuer;
         })
     }
     return snapshot;
 }
 
+
 // main
 void (async () => {
     console.log(`Auditing ${options.dirpath}`);
-
     try {
-        const directory = JSON.parse(fs.readFileSync(options.dirpath).toString('utf-8')) as TrustedIssuers;
-        const directoryLog = await fetchDirectoryKeys(directory);
-        fs.writeFileSync(options.outlogpath, JSON.stringify(directoryLog, null, 4));
-        console.log(`Directory log written to ${options.outlogpath}`);
-        // convert to snapshot
-        const directorySnapshot = directoryLogToSnapshot(directoryLog);
-        fs.writeFileSync(options.outpath, JSON.stringify(directorySnapshot, null, 4));
-        console.log(`Directory snapshot written to ${options.outpath}`);
-    } catch (e) {
-        console.log((e as Error).message);
-        return;
-    }
+        // dowload a fresh copy of the directory (with keys)
+        const directoryLog = await fetchDirectory(options.dirpath, options.verbose);
+        fs.writeFileSync(options.outlog, JSON.stringify(directoryLog, null, 4));
+        console.log(`Directory log written to ${options.outlog}`);
 
+        if (directoryLog) {
+            // save a snapshot of issuers (without errors) with keys and CRLs
+            const directorySnapshot = directoryLogToSnapshot(directoryLog);
+            fs.writeFileSync(options.outsnapshot, JSON.stringify(directorySnapshot, null, 4));
+            console.log(`Directory snapshot written to ${options.outsnapshot}`);
+        }
+        if (!directoryLog) {
+            throw "No directory available; aborting";
+        }
+
+        // the audit script optionally compare the directory with a previous version to highlight changes
+        let previousDirectoryLog: DirectoryLog | undefined = undefined;
+        if (options.previous) {
+            let errMsg = `Can't read ${options.previous}`;
+            try {
+                previousDirectoryLog = JSON.parse(fs.readFileSync(options.previous).toString('utf-8')) as DirectoryLog;
+            } catch (e) {
+                errMsg += (". " + (e as Error).message);
+            }
+            if (!previousDirectoryLog) {
+                console.log(errMsg);
+            }
+        }
+
+        // audit the directory, optionally comparing with a previous version
+        const auditLog = audit(directoryLog, previousDirectoryLog);
+        fs.writeFileSync(options.auditlog, JSON.stringify(auditLog, null, 4));
+        console.log(`Audit log written to ${options.auditlog}`);
+    } catch (err) {
+        console.log(err);
+    }
 })();

--- a/scripts/vci-directory-auditor/src/interfaces.ts
+++ b/scripts/vci-directory-auditor/src/interfaces.ts
@@ -2,8 +2,6 @@
 // interfaces
 //
 
-import { JWK } from "node-jose";
-
 export interface IssuerKey {
     kty: string,
     kid: string,
@@ -53,6 +51,8 @@ export interface IssuerLogInfo {
     crls?: CRL[],
     // errors while retrieving the issuer JWK set, if any
     errors?: string[]
+    // warnings about issuer configuration (TLS, CORS), if any
+    warnings?: string[]
 }
 
 // Key identifiers (KID) of one issuer
@@ -69,16 +69,6 @@ export interface DirectoryLog {
     time: string,
     // directory issuers
     issuerInfo: IssuerLogInfo[]
-}
-
-// a snapshot of the directory, including keys
-interface DirectorySnapshot {
-    // directory URL
-    directory: string,
-    // snapshot time
-    time: string,
-    // directory issuers
-    issuerInfo: IssuerInfoWithKeys[]
 }
 
 // audit log

--- a/scripts/vci-directory-auditor/src/interfaces.ts
+++ b/scripts/vci-directory-auditor/src/interfaces.ts
@@ -1,0 +1,111 @@
+//
+// interfaces
+//
+
+import { JWK } from "node-jose";
+
+export interface IssuerKey {
+    kty: string,
+    kid: string,
+    use: string,
+    alg: string,
+    crlVersion: number
+}
+
+// issuer info in the directory
+export interface TrustedIssuer {
+    iss: string,
+    name: string,
+    canonical_iss?: string,
+    website?: string
+}
+
+// directory structure
+export interface TrustedIssuers {
+    participating_issuers: TrustedIssuer[]
+}
+
+export interface TlsDetails {
+    version: string | undefined,
+    cipher: string | undefined,
+    kexAlg: string | undefined,
+    authAlg: string | undefined,
+    pubKeySize: string | undefined,
+    compression: string | undefined
+}
+
+export interface CRL {
+    kid: string,
+    method: string,
+    ctr: number,
+    rids: string[]
+}
+
+// issuer log info
+export interface IssuerLogInfo {
+    // the issuer info
+    issuer: TrustedIssuer,
+    // the issuer's JWK set
+    keys: IssuerKey[],
+    // the issuer's default TLS session details
+    tlsDetails?: TlsDetails | undefined,
+    // the issuer's cert revocation lists (CRLs)
+    crls?: CRL[],
+    // errors while retrieving the issuer JWK set, if any
+    errors?: string[]
+}
+
+// Key identifiers (KID) of one issuer
+export interface IssuerKids {
+    iss: string,
+    kids: string[]
+}
+
+// directory log, a snapshot of the directory
+export interface DirectoryLog {
+    // directory URL
+    directory: string,
+    // retrieval time
+    time: string,
+    // directory issuers
+    issuerInfo: IssuerLogInfo[]
+}
+
+// a snapshot of the directory, including keys
+interface DirectorySnapshot {
+    // directory URL
+    directory: string,
+    // snapshot time
+    time: string,
+    // directory issuers
+    issuerInfo: IssuerInfoWithKeys[]
+}
+
+// audit log
+export interface AuditLog {
+    // URL of the audited directory
+    directory: string,
+    // audit time
+    auditTime: string,
+    // previous audit time (if available)
+    previousAuditTime?: string,
+    // count of issuers present in the directory
+    issuerCount: number,
+    // count of issuers with CRLs
+    issuerWithCRLCount: number,
+    // count of new issuers since previous audit (if available)
+    newIssuerCount?: number,
+    // count of new issuers since previous audit (if available)
+    deletedIssuerCount?: number,
+    // issuers with errors during scan
+    issuersWithErrors: IssuerLogInfo[],
+    // duplicated key identifiers (KID) in the directory
+    duplicatedKids: string[],
+    // duplicated issuer URL (iss) in the directory
+    duplicatedIss: string[],    
+    // duplicated display name in the directory (not prohibited, but good to know)
+    duplicatedNames: string[],
+    // list of removed key identifiers since last audit (if available); should only
+    // occur when the corresponding key is revoked by the issuer
+    removedKids?: IssuerKids[]
+}


### PR DESCRIPTION
Migrated more features from the [vci-directory-auditor](https://github.com/christianpaquin/vci-directory-auditor) to perform full audit, including:
 * Parsing issuer CRLs
 * Checking issuer TLS config
 * Comparing two directory logs, listing added and deleted kid
 * Listing duplicated issuer names, urls, kids
 