### PR TITLE
Report OpenSSL errors in the audit log

### DIFF
--- a/scripts/vci-directory-auditor/src/bcp195.ts
+++ b/scripts/vci-directory-auditor/src/bcp195.ts
@@ -36,15 +36,14 @@ const openssl = (args: string[]): execa.ExecaSyncReturnValue<string> => {
 }
 
 // Connect to the specified server and return its default TLS connection details
-export function getDefaultTlsDetails(server: string): TlsDetails | undefined {
+export function getDefaultTlsDetails(server: string): TlsDetails | string | undefined {
     if (!isOpensslAvailable()) {
         console.log("OpenSSL not available");
         return undefined;
     }
     const result = openssl(['s_client', '-connect', `${server}:443`]);
     if (!result || result.failed) {
-        console.log(result ? result.stderr : "openssl failed");
-        return undefined;
+        return result ? `OpenSSL error: ${result.stderr}` : "OpenSSL failed";
     }
 
     let version = result.stdout.match(new RegExp('^    Protocol  : (.*)$', 'm'))?.[1];


### PR DESCRIPTION
During the TLS config check (performed in the audit script), some connections might result in OpenSSL errors. These are now reported in the audit log instead of simply being printed out on the console.