### PR TITLE
Correct American Samoa Two-Letter country code

### DIFF
--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -2131,7 +2131,7 @@
       "issuer_type": "governmental.state_province_territory",
       "locations": [
         {
-          "state": "SA",
+          "state": "AS",
           "country": "US"
         }
       ]


### PR DESCRIPTION
Corrects the American Samoa Two Letter Country Code

https://www.iso.org/obp/ui/#iso:code:3166:AS