### PR TITLE
rename DuPage Medical Group and Edward-Elmhurst Health to Edward-Elmh…

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -787,7 +787,7 @@
     },
     {
       "iss": "https://fhirprd.edward.org/fhirprd/api/epic/2021/Security/Open/EcKeys/32001/SHC",
-      "name": "DuPage Medical Group and Edward-Elmhurst Health"
+      "name": "Edward-Elmhurst Health"
     },
     {
       "iss": "https://apps.vdh.virginia.gov/credentials",


### PR DESCRIPTION
…urst Health

This was requested as DuPage Medical Group now has their own endpoint (Duly Health and Care), separate from Edward-Elmhurst's.