### PR TITLE
Update validation script to properly validate canonical iss entries

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -390,19 +390,21 @@ async def validate_entry(
         )
 
 async def validate_all_entries(
-    entries: List[IssuerEntry]
+    entries: List[IssuerEntry],
+    full_issuer_list: List[IssuerEntry]
 ) -> List[ValidationResult]:
-    entry_map = {entry.iss: entry for entry in entries}
+    full_issuer_entry_map = {entry.iss: entry for entry in full_issuer_list}
     asyncio_semaphore = asyncio.BoundedSemaphore(50)
-    aws = [validate_entry(issuer_entry, entry_map, asyncio_semaphore) for issuer_entry in entries]
+    aws = [validate_entry(issuer_entry, full_issuer_entry_map, asyncio_semaphore) for issuer_entry in entries]
     return await asyncio.gather(
         *aws
     )
 
 def validate_entries(
-    entries: List[IssuerEntry]
+    entries_to_validate: List[IssuerEntry],
+    full_issuer_list: List[IssuerEntry]
 ) -> List[ValidationResult]:
-    results = asyncio.run(validate_all_entries(entries))
+    results = asyncio.run(validate_all_entries(entries_to_validate, full_issuer_list))
     print('')
     return results
 

--- a/scripts/identify_entries_missing_cors.py
+++ b/scripts/identify_entries_missing_cors.py
@@ -12,7 +12,7 @@ def main():
     args = parser.parse_args()
     entries_from_json = common.read_issuer_entries_from_json_file(args.input_file)
 
-    validation_results = common.validate_entries(entries_from_json)
+    validation_results = common.validate_entries(entries_from_json, entries_from_json)
 
     invalid_cors_entries = []
 
@@ -23,13 +23,13 @@ def main():
 
     if len(invalid_cors_entries) > 0:
         writer = csv.DictWriter(
-            sys.stdout, 
+            sys.stdout,
             fieldnames=common.IssuerEntry._fields,
             delimiter='\t'
         )
         writer.writeheader()
         writer.writerows([entry._asdict() for entry in invalid_cors_entries])
-    
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/merge_issuers_files.py
+++ b/scripts/merge_issuers_files.py
@@ -13,7 +13,7 @@ def main():
     entries_from_json_2 = common.read_issuer_entries_from_json_file(args.input_file_2)
 
     ## validate entries_from_json_2
-    validation_results = common.validate_entries(entries_from_json_2)
+    validation_results = common.validate_entries(entries_from_json_2, entries_from_json_2)
     is_valid = common.analyze_results(validation_results, False, False)
     if not is_valid:
         print('One or more entries are invalid')
@@ -29,6 +29,6 @@ def main():
 
     merged_entries = list(merged_entry_dict.values())
     common.write_issuer_entries_to_json_file(args.output_file, merged_entries)
-        
+
 if __name__ == "__main__":
     main()

--- a/scripts/validate_diffs.py
+++ b/scripts/validate_diffs.py
@@ -38,10 +38,10 @@ def main():
     for change in changes:
         print(change)
 
-    additions_validation_results = common.validate_entries(additions)
+    additions_validation_results = common.validate_entries(additions, head_entries_from_json)
     additions_valid = common.analyze_results(additions_validation_results, True, args.show_warnings, cors_issue_is_error=True)
 
-    changes_validation_results = common.validate_entries(changes)
+    changes_validation_results = common.validate_entries(changes, head_entries_from_json)
     changes_valid = common.analyze_results(changes_validation_results, True, args.show_warnings, cors_issue_is_error=True)
 
     if additions_valid and changes_valid:

--- a/scripts/validate_entries.py
+++ b/scripts/validate_entries.py
@@ -19,7 +19,7 @@ def main():
             print(entry)
         exit(1)
 
-    validation_results = common.validate_entries(entries_from_json)
+    validation_results = common.validate_entries(entries_from_json, entries_from_json)
     valid = common.analyze_results(validation_results, True, args.show_warnings)
 
     if valid:


### PR DESCRIPTION
The issue is shown by this PR: https://github.com/the-commons-project/vci-directory/pull/625

**Explanation**: when validating a canonical reference, the validation script (in theory) checks that the canonical reference resolves to another issuer in VCI. However, the script was only checking against a subset of issuers; specifically, it was only checking against the same list that's being validated overall (i.e. changes introduced by a specific PR). 

So in the scenario of adding a new issuer in a PR, with a canonical reference to an existing VCI issuer, the script would complain that it's an invalid reference. 

**Fix**: pass in the full issuer list as contained in the PR branch head, so a full lookup can be performed.

