### PR TITLE
add Epic-Hosted Physician Practice

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -2934,6 +2934,11 @@
       "iss": "https://epicproxy.et1254.epichosted.com/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "Aspen Valley Hospital",
       "website": "https://www.aspenhospital.org/patients/patient-portal/"
+    },
+    {
+      "iss": "https://epicproxy.et4001.epichosted.com/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
+      "name": "Epic-Hosted Physician Practice",
+      "website": "https://login.yourepicmychart.com/MyChart/Authentication/Login?"
     }
   ]
 }


### PR DESCRIPTION
https://epicproxy.et4001.epichosted.com/FHIRProxy/api/epic/2021/Security/Open/EcKeys/32001/SHC

(Note that this will cover multiple organizations - currently MyDrNow and Drexel)

@edwardjcruz Do we have an idea of how we'd like to handle this in the Metadata file? This endpoint will be primarily used by organizational.health_system issuers, but it won't necessarily remain restricted to given states (nor be particularly informative for patients if it is available in their state)