### PR TITLE
Add missing label for New York state

### DIFF
--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -8030,6 +8030,7 @@
             "website":"https://myvaccinerecord.cityofnewyork.us/prod/myrecord-react/",
             "issuer_type":"governmental.state_province_territory",
             "currently_issuing":false,
+            "label":"New York",
             "locations":[
                 {
                     "state":"NY",


### PR DESCRIPTION
The `label` value must be present for governmental issuers.