### PR TITLE
Fix whitespace in issuer metadata ISS

### DIFF
--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -7925,7 +7925,7 @@
             ]
          },
         {
-            "canonical_iss":" https://w1soap.wakehealth.edu/fhirproxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
+            "canonical_iss":"https://w1soap.wakehealth.edu/fhirproxy/api/epic/2021/Security/Open/EcKeys/32001/SHC",
             "website":"https://www.mywakehealth.org/mychart/Authentication/Login?",
             "issuer_type":"organizational.health_system",
             "locations":[


### PR DESCRIPTION
Fixes whitespace before an issuer's canonical iss in the metadata. This whitespace caused the issuer to be skipped on https://smarthealth.cards.