### PR TITLE
changed the token from a PAT to the default Github token

### DIFF
--- a/.github/workflows/vci-directory-audit.yaml
+++ b/.github/workflows/vci-directory-audit.yaml
@@ -9,10 +9,10 @@ jobs:
   vci-directory-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
-          token: ${{ secrets.GIT_PUSH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
the previously created PAT GIT_PUSH_TOKEN was failing
updated to v3 from v2 for the checkout action