### PR TITLE
Add North Dakota

### DIFF
--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -8140,6 +8140,18 @@
                     "country":"US"
                 }
             ]
+        },
+        {
+            "canonical_iss":"https://docket.care/nd",
+            "website":"https://www.hhs.nd.gov/IRR/",
+            "label":"North Dakota",
+            "issuer_type":"governmental.state_province_territory",
+            "locations":[
+                {
+                    "state":"ND",
+                    "country":"US"
+                }
+            ]
         }
     ]
 }

--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -3145,6 +3145,11 @@
       "iss": "https://epicproxy.et1342.epichosted.com/APIProxyPRD/api/epic/2021/Security/Open/EcKeys/32001/SHC",
       "name": "Methodist Le Bonheur",
       "website": "https://mychart.methodisthealth.org/MyChart/"
+    },
+    {
+      "iss": "https://docket.care/nd",
+      "name": "State of North Dakota",
+      "website": "https://www.hhs.nd.gov/IRR/"
     }
   ]
 }


### PR DESCRIPTION
Docket now supports Smarth Health Links in North Dakota.