### PR TITLE
Add Washington, DC

### DIFF
--- a/vci-issuers-metadata.json
+++ b/vci-issuers-metadata.json
@@ -8152,6 +8152,18 @@
                     "country":"US"
                 }
             ]
+        },
+        {
+            "canonical_iss":"https://docket.care/dc",
+            "website":"https://dchealth.dc.gov/immunization",
+            "label":"District of Columbia",
+            "issuer_type":"governmental.state_province_territory",
+            "locations":[
+                {
+                    "state":"DC",
+                    "country":"US"
+                }
+            ]
         }
     ]
 }

--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -3150,6 +3150,11 @@
       "iss": "https://docket.care/nd",
       "name": "State of North Dakota",
       "website": "https://www.hhs.nd.gov/IRR/"
+    },
+    {
+      "iss": "https://docket.care/dc",
+      "name": "District of Columbia",
+      "website": "https://dchealth.dc.gov/immunization"
     }
   ]
 }


### PR DESCRIPTION
Docket now supports Smarth Health Links in Washington, D.C.