### PR TITLE
Fix up GH actions because YAML is a miserable mark up language

### DIFF
--- a/.github/workflows/test-scripts.yaml
+++ b/.github/workflows/test-scripts.yaml
@@ -17,11 +17,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: 'head'
-
-     - uses: actions/checkout@v4
-       with:
-         ref: ${{ github.event.pull_request.base.sha }}
-         path: 'base'
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: 'base'
 
       - name: Cache Python venv
         uses: actions/cache@v4

--- a/.github/workflows/upload-snapshot.yaml
+++ b/.github/workflows/upload-snapshot.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: "List bucket"
         run: |
           echo "uploading to ${{matrix.bucket}}"
-
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
       - name: 'Configure AWS Role'
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/validate-issuers-periodic.yaml
+++ b/.github/workflows/validate-issuers-periodic.yaml
@@ -2,17 +2,18 @@ name: "Validate on schedule"
 
 on:
   schedule:
-    - cron:  '*/60 */4 * * *'
+    # Minute Hour DayOfMonth Month DayOfWeek - runs every 4 hours
+    # This only applies to whatever has been set as the main branch
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+    - cron:  '0 */4 * * *'
 
 jobs:
   runTests:
     name: "Validate Issuers File"
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
+      - name: Checkout Code
+        uses: actions/checkout@v4
       - name: Cache Python venv
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Sooo here's a cool story: YAML that is arbitrarily truncated is still valid YAML. It's possible one of the worst possible mark up languages every invented, and it's very finicky about whitespace.

The original file is invalid.

<img width="837" height="572" alt="Screenshot 2025-09-03 at 4 56 37 PM" src="https://github.com/user-attachments/assets/7ee0b207-9680-4057-a781-ae769a35fb28" />

Add 3 spaces on those 4 lines I changed and it's then valid.

I also removed some unnecessary calls that use really strong references in the checkout action. It defaults to whatever the SHA is of what triggered the workflow, so it should "just work" in most cases.