### PR TITLE
Add International Organization for Migration (IOM) issuer

### DIFF
--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -3158,7 +3158,8 @@
     },
     {
       "iss": "https://api-global-ext.iom.int/smarthealth",
-      "name": "International Organization for Migration"
+      "name": "International Organization for Migration",
+      "website": "https://www.iom.int"
     }
   ]
 }

--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -3155,6 +3155,11 @@
       "iss": "https://docket.care/mo",
       "name": "Missouri",
       "website": "https://health.mo.gov/living/wellness/immunizations"
-    }    
+    },
+    {
+      "iss": "https://api-global-ext.iom.int/smarthealth",
+      "name": "International Organization for Migration",
+      "website": "https://www.iom.int"
+    }
   ]
 }

--- a/vci-issuers.json
+++ b/vci-issuers.json
@@ -3158,8 +3158,7 @@
     },
     {
       "iss": "https://api-global-ext.iom.int/smarthealth",
-      "name": "International Organization for Migration",
-      "website": "https://www.iom.int"
+      "name": "International Organization for Migration"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds the **International Organization for Migration (IOM)** to the VCI Directory (`vci-issuers.json`), approved by JP Pollak.

| Field | Value |
|-------|-------|
| `iss` | `https://api-global-ext.iom.int/smarthealth` (production) |
| `name` | International Organization for Migration |
| `website` | https://www.iom.int |

## Context
IOM completed the CommonTrust Network join process. Production ISS provided by Gary Domingo (IOM National ICT Officer). TCP engineering confirmed the QR codes and keys pass testing.

## Verification
- `vci-issuers.json` parses as valid JSON (638 issuers)
- `iss` uses `https` and has no trailing slash (per issuer requirements)
- JWKS at `https://api-global-ext.iom.int/smarthealth/.well-known/jwks.json` returns **HTTP 200** with a valid EC / ES256 (P-256, `use=sig`) signing key